### PR TITLE
Bumping deps for no good reason is bad mkay? :)

### DIFF
--- a/lib/Class/Method/Modifiers.pm
+++ b/lib/Class/Method/Modifiers.pm
@@ -2,7 +2,9 @@ package Class::Method::Modifiers;
 use strict;
 use warnings;
 
-use Exporter 5.57 'import';
+# work around https://rt.cpan.org/Ticket/Display.html?id=89173
+use base ('Exp'.'orter');
+
 our @EXPORT = qw(before after around);
 our @EXPORT_OK = (@EXPORT, qw(fresh install_modifier));
 our %EXPORT_TAGS = (


### PR DESCRIPTION
On one hand @karenetheridge is right (except for the dzil is great part)

```
<ether> and yes, because keeping MinimumVersion means that if something else tries to add a 5.8 dependency, I'll see a release test fail
<ether> so keeping it is better than removing it
<ether> if I remove it entirely, I have to remember to do that check manually, and not having to remember to do manual steps is what makes dzil great
```

But so is @haarg:
`<haarg> you switched from the thing that works in all perl to the thing that doesn't work with old Exporter because of a bug in MinimumVersion?`

The solution is obvious - don't add moving parts where the code functionality does not require it, and keep _everyone_ happy.
