### PR TITLE
Add explicit documentation for modifying multiple methods

### DIFF
--- a/lib/Class/Method/Modifiers.pm
+++ b/lib/Class/Method/Modifiers.pm
@@ -293,7 +293,14 @@ C<fresh>; see below.
 
 =head1 MODIFIERS
 
-=head2 before method(s) => sub { ... }
+All modifiers let you modify one or multiple methods at a time. The names of
+multiple methods can be provided as a list or as an array-reference. Examples:
+
+ before 'method' => sub { ... };
+ before 'method1', 'method2' => sub { ... };
+ before [ 'method1', 'method2' ] => sub { ... };
+
+=head2 before method(s) => sub { ... };
 
 C<before> is called before the method it is modifying. Its return value is
 totally ignored. It receives the same C<@_> as the method it is modifying
@@ -301,7 +308,7 @@ would have received. You can modify the C<@_> the original method will receive
 by changing C<$_[0]> and friends (or by changing anything inside a reference).
 This is a feature!
 
-=head2 after method(s) => sub { ... }
+=head2 after method(s) => sub { ... };
 
 C<after> is called after the method it is modifying. Its return value is
 totally ignored. It receives the same C<@_> as the method it is modifying
@@ -310,7 +317,7 @@ C<$_[0]> or references) and C<after> will see the modified version. If you
 don't like this behavior, specify both a C<before> and C<after>, and copy the
 C<@_> during C<before> for C<after> to use.
 
-=head2 around method(s) => sub { ... }
+=head2 around method(s) => sub { ... };
 
 C<around> is called instead of the method it is modifying. The method you're
 overriding is passed in as the first argument (called C<$orig> by convention).


### PR DESCRIPTION
Modifiers lacked explicit documentation on modifying multiple methods at once. The SYNOPSIS contains an example, but that was hard to find for someone who wanted to quickly look up the correct syntax.
