### PR TITLE
Disable warning

### DIFF
--- a/lib/Class/Method/Modifiers.pm
+++ b/lib/Class/Method/Modifiers.pm
@@ -50,6 +50,7 @@ sub install_modifier {
         # this must be the first modifier we're installing
         if (!exists($cache->{"orig"})) {
             no strict 'refs';
+            no warnings 'once';
 
             # grab the original method (or undef if the method is inherited)
             $cache->{"orig"} = *{$qualified}{CODE};


### PR DESCRIPTION
Not totally sure if this the right thing to do.  But it fixes my problem.

I was getting a warning running the following code.  

```
package MyPackage;
use Moo;
around 'Test::Selenium::Remote::WebElement::has_args' => sub {...};
```

The warning was:

```
Name "MyPackage::Test::Selenium::Remote::WebElement::has_args" used only once: possible typo at local/lib/perl5/Class/Method/Modifiers.pm line 60.
```
