### PR TITLE
add support for modifying operators

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,14 +19,15 @@ Test::ReportPrereqs.include[6] = namespace::autoclean
 
 [Prereqs / RuntimeRequires]
 Exporter = 0
+MRO::Compat = 0
 
 [Prereqs / DevelopRequires]
 Test::Warnings = 0
 Moose = 0
 Perl::MinimumVersion = 1.35 ; for RT#89173
 
-[OnlyCorePrereqs]
-phase = configure
-phase = build
-phase = runtime
-check_dual_life_versions = 0
+; [OnlyCorePrereqs]
+; phase = configure
+; phase = build
+; phase = runtime
+; check_dual_life_versions = 0

--- a/lib/Class/Method/Modifiers.pm
+++ b/lib/Class/Method/Modifiers.pm
@@ -259,10 +259,9 @@ sub _overloaded_op_method {
     my $coderef;
     my $method_name;
 
+    my $isa = mro::get_linear_isa( $class );
 
-    my @isa = @{ mro::get_linear_isa( $class ) };
-
-    for my $pkg ( @isa ) {
+    for my $pkg ( @$isa ) {
 
         next
           unless defined( $coderef = *{ _getglob "${pkg}::${symbol}" }{CODE} );

--- a/lib/Class/Method/Modifiers.pm
+++ b/lib/Class/Method/Modifiers.pm
@@ -301,7 +301,7 @@ sub _overloaded_op_method {
 
         my $glob = _getglob "${class}::${symbol}";
         *$glob = \$method_name;
-	no warnings 'redefine';
+        no warnings 'redefine';
         *$glob = \&overload::nil || \&overload::_nil;
 
     }

--- a/t/150-operators.t
+++ b/t/150-operators.t
@@ -9,15 +9,15 @@ subtest 'method name' => sub {
   @seen = ();
 
   my @expected = ("Child::++ before 2",
-		    "Child::++ before 1",
-		       "Child::++ around 2 before",
-			 "Child::++ around 1 before",
-			   "Parent::++",
-			 "Child::++ around 1 after",
-		       "Child::++ around 2 after",
-		    "Child::++ after 1",
-		  "Child::++ after 2",
-		 );
+                    "Child::++ before 1",
+                       "Child::++ around 2 before",
+                         "Child::++ around 1 before",
+                           "Parent::++",
+                         "Child::++ around 1 after",
+                       "Child::++ around 2 after",
+                    "Child::++ after 1",
+                  "Child::++ after 2",
+                 );
 
   my $child = Child->new; $child++;
 
@@ -29,15 +29,15 @@ subtest 'coderef' => sub {
   @seen = ();
 
   my @expected = ("Child::-- before 2",
-		    "Child::-- before 1",
-		       "Child::-- around 2 before",
-			 "Child::-- around 1 before",
-			   "Parent::--",
-			 "Child::-- around 1 after",
-		       "Child::-- around 2 after",
-		    "Child::-- after 1",
-		  "Child::-- after 2",
-		 );
+                    "Child::-- before 1",
+                       "Child::-- around 2 before",
+                         "Child::-- around 1 before",
+                           "Parent::--",
+                         "Child::-- around 1 after",
+                       "Child::-- around 2 after",
+                    "Child::-- after 1",
+                  "Child::-- after 2",
+                 );
 
   my $child = Child->new; $child--;
 
@@ -50,7 +50,7 @@ BEGIN {
 
     use overload
         '++' => 'plus',
-	'--' => sub { push @seen, __PACKAGE__ . "::--" };
+        '--' => sub { push @seen, __PACKAGE__ . "::--" };
 
     sub new { bless {}, shift }
 
@@ -69,41 +69,41 @@ BEGIN {
 
         my $op = $_;
 
-	before $op => sub
-	{
-	    push @seen, __PACKAGE__ . "::$op before 1";
-	};
+        before $op => sub
+        {
+            push @seen, __PACKAGE__ . "::$op before 1";
+        };
 
-	before $op => sub
-	{
-	    push @seen, __PACKAGE__ . "::$op before 2";
-	};
+        before $op => sub
+        {
+            push @seen, __PACKAGE__ . "::$op before 2";
+        };
 
-	around $op => sub
-	{
-	    my $orig = shift;
-	    push @seen, __PACKAGE__ . "::$op around 1 before";
-	    $orig->();
-	    push @seen, __PACKAGE__ . "::$op around 1 after";
-	};
+        around $op => sub
+        {
+            my $orig = shift;
+            push @seen, __PACKAGE__ . "::$op around 1 before";
+            $orig->();
+            push @seen, __PACKAGE__ . "::$op around 1 after";
+        };
 
-	around $op => sub
-	{
-	    my $orig = shift;
-	    push @seen, __PACKAGE__ . "::$op around 2 before";
-	    $orig->();
-	    push @seen, __PACKAGE__ . "::$op around 2 after";
-	};
+        around $op => sub
+        {
+            my $orig = shift;
+            push @seen, __PACKAGE__ . "::$op around 2 before";
+            $orig->();
+            push @seen, __PACKAGE__ . "::$op around 2 after";
+        };
 
-	after $op => sub
-	{
-	    push @seen, __PACKAGE__ . "::$op after 1";
-	};
+        after $op => sub
+        {
+            push @seen, __PACKAGE__ . "::$op after 1";
+        };
 
-	after $op => sub
-	{
-	    push @seen, __PACKAGE__ . "::$op after 2";
-	};
+        after $op => sub
+        {
+            push @seen, __PACKAGE__ . "::$op after 2";
+        };
 
     }
 

--- a/t/150-operators.t
+++ b/t/150-operators.t
@@ -1,0 +1,112 @@
+use strict;
+use warnings;
+use Test::More 0.88;
+use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
+
+my @seen;
+
+subtest 'method name' => sub {
+  @seen = ();
+
+  my @expected = ("Child::++ before 2",
+		    "Child::++ before 1",
+		       "Child::++ around 2 before",
+			 "Child::++ around 1 before",
+			   "Parent::++",
+			 "Child::++ around 1 after",
+		       "Child::++ around 2 after",
+		    "Child::++ after 1",
+		  "Child::++ after 2",
+		 );
+
+  my $child = Child->new; $child++;
+
+  is_deeply(\@seen, \@expected, "multiple before/around/after called in the right order");
+};
+
+subtest 'coderef' => sub {
+
+  @seen = ();
+
+  my @expected = ("Child::-- before 2",
+		    "Child::-- before 1",
+		       "Child::-- around 2 before",
+			 "Child::-- around 1 before",
+			   "Parent::--",
+			 "Child::-- around 1 after",
+		       "Child::-- around 2 after",
+		    "Child::-- after 1",
+		  "Child::-- after 2",
+		 );
+
+  my $child = Child->new; $child--;
+
+  is_deeply(\@seen, \@expected, "multiple before/around/after called in the right order");
+};
+
+
+BEGIN {
+    package Parent;
+
+    use overload
+        '++' => 'plus',
+	'--' => sub { push @seen, __PACKAGE__ . "::--" };
+
+    sub new { bless {}, shift }
+
+    sub plus
+    {
+        push @seen, __PACKAGE__ . "::++";
+    }
+}
+
+BEGIN {
+    package Child;
+    our @ISA = 'Parent';
+    use Class::Method::Modifiers;
+
+    for ( qw[ ++ -- ] ) {
+
+        my $op = $_;
+
+	before $op => sub
+	{
+	    push @seen, __PACKAGE__ . "::$op before 1";
+	};
+
+	before $op => sub
+	{
+	    push @seen, __PACKAGE__ . "::$op before 2";
+	};
+
+	around $op => sub
+	{
+	    my $orig = shift;
+	    push @seen, __PACKAGE__ . "::$op around 1 before";
+	    $orig->();
+	    push @seen, __PACKAGE__ . "::$op around 1 after";
+	};
+
+	around $op => sub
+	{
+	    my $orig = shift;
+	    push @seen, __PACKAGE__ . "::$op around 2 before";
+	    $orig->();
+	    push @seen, __PACKAGE__ . "::$op around 2 after";
+	};
+
+	after $op => sub
+	{
+	    push @seen, __PACKAGE__ . "::$op after 1";
+	};
+
+	after $op => sub
+	{
+	    push @seen, __PACKAGE__ . "::$op after 2";
+	};
+
+    }
+
+}
+
+done_testing;


### PR DESCRIPTION
This changeset adds support for modifying operator overloads.  For overloads which are coderefs rather than method names, it creates a named entry in the package's symbol table for the coderef and updates the overloaded operator with that name.  That is then used by the modifiers.

Unfortunately there is now a dependency on mro/MRO::Compat.  Using the "can" method on the overload entries in the symbol table messes up the overload mechanism (see overload::mycan, which since 5.10 uses mro).  I could switch the code to use overload::mycan, but I'll be honest in that I don't know what affect that'll have on pre-mro Perls.