### PR TITLE
drop Test::Fatal prereq

### DIFF
--- a/t/001-error.t
+++ b/t/001-error.t
@@ -2,14 +2,13 @@ use strict;
 use warnings;
 use Test::More 0.88;
 use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
-use Test::Fatal;
 
 do {
     package Class1;
     use Class::Method::Modifiers;
 
-    ::like(
-      ::exception { before foo => sub {}; },
+    eval { before foo => sub {}; };
+    ::like($@,
       qr/The method 'foo' is not found in the inheritance hierarchy for class Class1/,
     );
 };
@@ -18,8 +17,9 @@ do {
     package Class2;
     use Class::Method::Modifiers;
 
+    eval { after foo => sub {}; };
     ::like(
-      ::exception { after foo => sub {}; },
+      $@,
       qr/The method 'foo' is not found in the inheritance hierarchy for class Class2/,
     );
 };
@@ -28,8 +28,9 @@ do {
     package Class3;
     use Class::Method::Modifiers;
 
+    eval { around foo => sub {}; };
     ::like(
-      ::exception { around foo => sub {}; },
+      $@,
       qr/The method 'foo' is not found in the inheritance hierarchy for class Class3/,
     );
 };
@@ -40,8 +41,9 @@ do {
 
     sub foo {}
 
+    eval { around 'foo', 'bar' => sub {}; };
     ::like(
-      ::exception { around 'foo', 'bar' => sub {}; },
+      $@,
       qr/The method 'bar' is not found in the inheritance hierarchy for class Class4/,
     );
 };

--- a/t/120-fresh.t
+++ b/t/120-fresh.t
@@ -3,7 +3,6 @@ use warnings;
 
 use Test::More 0.88;
 use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
-use Test::Fatal;
 
 use B 'svref_2object';
 
@@ -62,28 +61,34 @@ for my $class (qw(P2 P3)) {
 {
     package P2;
 
-    ::like(::exception { fresh m1 => sub {} },
+    eval { fresh m1 => sub {} };
+    ::like($@,
            qr/^Class P2 already has a method named 'm1'/,
            'fresh: exception when inherited method exists');
 
-    ::like(::exception { fresh m6 => sub {} },
+    eval { fresh m6 => sub {} };
+    ::like($@,
            qr/^Class P2 already has a method named 'm6'/,
            'fresh: exception when local method exists');
 
-    ::like(::exception { fresh '=:=' => sub {} },
+    eval { fresh '=:=' => sub {} };
+    ::like($@,
            qr/^Invalid method name '=:='/,
            'fresh: exception when name invalid');
 }
 
-like(exception { install_modifier P3 => fresh => m1 => sub {} },
+eval { install_modifier P3 => fresh => m1 => sub {} };
+like($@,
      qr/^Class P3 already has a method named 'm1'/,
      'install_modifier: exception when inherited method exists');
 
-like(exception { install_modifier P3 => fresh => m6 => sub {} },
+eval { install_modifier P3 => fresh => m6 => sub {} };
+like($@,
      qr/^Class P3 already has a method named 'm6'/,
      'install_modifier: exception when local method exists');
 
-like(exception { install_modifier P3 => fresh => '=:=' => sub {} },
+eval { install_modifier P3 => fresh => '=:=' => sub {} };
+like($@,
      qr/^Invalid method name '=:='/,
      'install_modifier: exception when name invalid');
 

--- a/t/140-lvalue.t
+++ b/t/140-lvalue.t
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 use Test::More 0.88;
 use if $ENV{AUTHOR_TESTING}, 'Test::Warnings';
-use Test::Fatal;
 
 {
   package WithLvalue;
@@ -70,8 +69,9 @@ is(After->lvalue_method, 4, 'after maintains lvalue attribute');
 
 {
   local $TODO = "can't apply after to array lvalue method";
-  is exception { (After->array_lvalue) = (3,4) }, undef,
-    'assigning to array lvalue attribute causes no errors';
+  ok eval { (After->array_lvalue) = (3,4); 1 },
+    'assigning to array lvalue attribute causes no errors'
+    or diag 'error: ', $@;
   is_deeply([After->array_lvalue], [3,4],
     'after array lvalue attribute sets values');
 }
@@ -87,8 +87,9 @@ is(After->lvalue_method, 4, 'after maintains lvalue attribute');
   after lvalue_proto_method => sub {};
 }
 
-is exception { LvalueWithProto->lvalue_proto_method = 4 }, undef,
-  'after maintains lvalue attribute with prototype present';
+ok eval { LvalueWithProto->lvalue_proto_method = 4; 1 },
+  'after maintains lvalue attribute with prototype present'
+    or diag 'error: ', $@;
 is(LvalueWithProto->lvalue_proto_method, 4,
   'after with lvalue and prototype correctly assigns');
 


### PR DESCRIPTION
The things this dist needs to test its exceptions is minimal, and Test::Fatal can trivially be replaced with some evals. This protects against any future changes to Test::Fatal, as well as removes two non-core prereqs.