### PR TITLE
use B for detecting methods rather than Moose

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -23,7 +23,6 @@ Exporter = 0
 
 [Prereqs / DevelopRequires]
 Test::Warnings = 0
-Moose = 0
 Perl::MinimumVersion = 1.35 ; for RT#89173
 
 [OnlyCorePrereqs]


### PR DESCRIPTION
Rather than using Moose, and protected by a Test::Needs check, use B to check the package of subs to detect if they are methods.

Since we aren't using Moose to create anything in the test, we don't need to care about any of Moose's own tracking or other things it cares about like roles. We only are using it to check is the package name attached to the sub. This can be done directly with B. This allows dropping the hard dependency on Test::Needs, and always run this test.