### PR TITLE
Fix _sub_attrs for perl 5.37.9

### DIFF
--- a/lib/Class/Method/Modifiers.pm
+++ b/lib/Class/Method/Modifiers.pm
@@ -208,6 +208,7 @@ sub _sub_attrs {
     my ($coderef) = @_;
     local *_sub = $coderef;
     local $@;
+    local $SIG{__DIE__};
     # this assignment will fail to compile if it isn't an lvalue sub.  we
     # never want to actually call the sub though, so we return early.
     (eval 'return 1; &_sub = 1') ? ':lvalue' : '';


### PR DESCRIPTION
This fixes an issue with _sub_attrs() where it does not localize `$SIG{__DIE__}` when it does its eval probe. A fix to Perl 5.37.9 made it so that `$SIG{__DIE__}` is always called on a compile error, unlike before where it depended on the nature of the error and how many errors.

See:
https://github.com/Perl/perl5/pull/20357
https://rt.cpan.org/Ticket/Display.html?id=146848
https://github.com/Perl/perl5/issues/20885
https://github.com/fany/MIME-Signature/issues/3


This also fixes the spelling issues reported in https://rt.cpan.org/Ticket/Display.html?id=146847

It also bumps the version. Once this is released with the _sub_attrs fix, MIME::Signature needs to be updated to depend on the new version. Please coordinate with https://github.com/fany/MIME-Signature/issues/3 and https://github.com/fany/MIME-Signature/pull/4